### PR TITLE
smallrye-health as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,34 @@ Or add to you pom.xml directly:
 Now that you configured your POM to use the service, now you need to configure which scanner(s) you want to use in `application.properties`:
 
 ### ClamAV
+
 [ClamAV](https://www.clamav.net/) is an open source Linux based virus scanning engine.
 If you don't set a host `quarkus.antivirus.clamav.host` a DevService will start a ClamAV instance for you on a dynamic free port, so you can test locally during development.
 
 ```properties
 quarkus.antivirus.clamav.enabled=true
-quarkus.antivirus.clamav.health.enabled=true
 ```
+
+#### ClamAV Health Check
+
+If you are using the `quarkus-smallrye-health` extension,
+quarkus-vault can add a readiness health check to validate the connection to the ClamAV server.
+
+If enabled (by default) and the extension is present,
+when you access the `/q/health/ready` endpoint of your application you will have information about the connection validation status.
+
+You can disable this behavior by setting the property `quarkus.antivirus.clamav.health.enabled` to `false` in your application.properties.
 
 ### VirusTotal
 
 [VirusTotal](https://www.virustotal.com/) is a REST API that analyses suspicious files to detect malware using over 70 antivirus scanners.  VirusTotal checks the hash of a file to see if it has been scanned and what the results are.  You can set the threshold of how many of the 70+ engines you want to report the file as malicious before you consider it a malicious file using the `minimum-votes` property.
+
 ```properties
 quarkus.antivirus.virustotal.enabled=true
 quarkus.antivirus.virustotal.key=<YOUR API KEY>
 quarkus.antivirus.virustotal.minimum-votes=1
 ```
+
 ## Usage
 
 Simply inject the `Antivirus` service, and it will run the scan against all configured services.  It works against `InputStream` so it can be used in any Quarkus application it is not constrained to REST applications only.

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-health-deployment</artifactId>
+      <artifactId>quarkus-smallrye-health-spi</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -47,6 +47,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/deployment/src/main/java/io/quarkiverse/antivirus/deployment/AntivirusProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/antivirus/deployment/AntivirusProcessor.java
@@ -8,6 +8,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
 /**
  * Main processor for the Antivirus extension.
@@ -29,12 +30,10 @@ class AntivirusProcessor {
                 .addBeanClasses(VirusTotalEngine.class)
                 .addBeanClasses(Antivirus.class)
                 .build());
+    }
 
-        // health check
-        if (buildConfig.healthEnabled()) {
-            beans.produce(AdditionalBeanBuildItem.builder().setUnremovable()
-                    .addBeanClasses(ClamAVHealthCheck.class)
-                    .build());
-        }
+    @BuildStep
+    HealthBuildItem addHealthCheck(ClamAVBuildConfig buildConfig) {
+        return new HealthBuildItem(ClamAVHealthCheck.class.getName(), buildConfig.healthEnabled());
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/antivirus/test/AntivirusDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/antivirus/test/AntivirusDevModeTest.java
@@ -16,7 +16,7 @@ public class AntivirusDevModeTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Test
-    public void writeYourOwnDevModeTest() {
+    void writeYourOwnDevModeTest() {
         // Write your dev mode tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
         Assertions.assertTrue(true, "Add dev mode assertions to " + getClass().getName());
     }

--- a/deployment/src/test/java/io/quarkiverse/antivirus/test/AntivirusTest.java
+++ b/deployment/src/test/java/io/quarkiverse/antivirus/test/AntivirusTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
 
 public class AntivirusTest {
 
@@ -16,8 +17,13 @@ public class AntivirusTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Test
-    public void writeYourOwnUnitTest() {
+    void writeYourOwnUnitTest() {
         // Write your unit tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
         Assertions.assertTrue(true, "Add some assertions to " + getClass().getName());
+    }
+
+    @Test
+    void testHealthServlet() {
+        RestAssured.when().get("/q/health").then().statusCode(404);
     }
 }

--- a/integration-tests/imperative/pom.xml
+++ b/integration-tests/imperative/pom.xml
@@ -30,6 +30,10 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkiverse.antivirus</groupId>
       <artifactId>quarkus-antivirus</artifactId>
       <version>${project.version}</version>

--- a/integration-tests/imperative/src/main/resources/application.properties
+++ b/integration-tests/imperative/src/main/resources/application.properties
@@ -3,7 +3,6 @@ quarkus.http.limits.max-body-size=200m
 quarkus.antivirus.clamav.enabled=true
 quarkus.antivirus.clamav.chunk-size=30000
 quarkus.antivirus.clamav.devservice.fresh-clam=false
-quarkus.antivirus.clamav.health.enabled=true
 # VirusTotal
 quarkus.antivirus.virustotal.enabled=true
 quarkus.antivirus.virustotal.key=<YOUR KEY HERE>

--- a/integration-tests/imperative/src/test/java/io/quarkiverse/antivirus/it/ClamAVResourceTest.java
+++ b/integration-tests/imperative/src/test/java/io/quarkiverse/antivirus/it/ClamAVResourceTest.java
@@ -18,7 +18,7 @@ import io.restassured.response.Response;
 public class ClamAVResourceTest {
 
     @Test
-    public void testValidFile() {
+    void testValidFile() {
         given()
                 .when().get("/clamav/valid")
                 .then()
@@ -27,7 +27,7 @@ public class ClamAVResourceTest {
     }
 
     @Test
-    public void testInvalidFile() {
+    void testInvalidFile() {
         RestAssured.defaultParser = Parser.TEXT;
         Response response = given()
                 .contentType(ContentType.TEXT)
@@ -43,5 +43,10 @@ public class ClamAVResourceTest {
             assertThat(stack, containsStringIgnoringCase(
                     "Scan detected viruses in file 'invalid.txt'! Virus scanner message = stream: Win.Test.EICAR_HDB-1 FOUND"));
         }
+    }
+
+    @Test
+    void testHealthServlet() {
+        RestAssured.when().get("/q/health").then().statusCode(200);
     }
 }

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -23,6 +23,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/runtime/src/main/java/io/quarkiverse/antivirus/runtime/ClamAVHealthCheck.java
+++ b/runtime/src/main/java/io/quarkiverse/antivirus/runtime/ClamAVHealthCheck.java
@@ -17,15 +17,21 @@ public class ClamAVHealthCheck implements HealthCheck {
 
     @Inject
     ClamAVEngine engine;
+
     @Inject
     ClamAVRuntimeConfig config;
 
     @Override
     public HealthCheckResponse call() {
-        final String server = String.format("%s:%s", config.host(), config.port());
+        final String host = config.host().orElseThrow();
+        final String server = String.format("%s:%s", host, config.port());
+
         HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("ClamAV Daemon");
-        responseBuilder = engine.ping() ? responseBuilder.up().withData(server, "UP")
+
+        responseBuilder = engine.ping()
+                ? responseBuilder.up().withData(server, "UP")
                 : responseBuilder.down().withData(server, "DOWN");
+
         return responseBuilder.build();
     }
 }


### PR DESCRIPTION
Set the `smallrye-health` dependency as optional following the quarkus way: https://quarkus.io/guides/writing-extensions#extension-health-check