### PR TITLE
update to quarkus 3.7 and java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,13 @@ defaults:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} - ${{ matrix.java }}
     strategy:
       fail-fast: false
       matrix:
 #        os: [windows-latest, macos-latest, ubuntu-latest]
         os: [ubuntu-latest]
+        java: ['17', '21']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Prepare git
@@ -45,11 +46,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
 
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK ${{matrix.java}}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: ${{matrix.java}}
           cache: 'maven'
 
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,10 @@
   </scm>
   <properties>
     <compiler-plugin.version>3.12.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.2.9.Final</quarkus.version>
+    <quarkus.version>3.7.1</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Update to the latest quarkus version:

* Java 17 as minimum version like quarkus: https://quarkus.io/blog/quarkus-3-7-released/
* Add Java 21 to the CI
