### PR TITLE
Fix #75: use ClamAV Debian image for Mac M1 Support

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/antivirus/deployment/ClamAVBuildConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/antivirus/deployment/ClamAVBuildConfig.java
@@ -20,7 +20,7 @@ public interface ClamAVBuildConfig {
     /**
      * Default docker image name.
      */
-    String DEFAULT_IMAGE = "clamav/clamav";
+    String DEFAULT_IMAGE = "clamav/clamav-debian";
 
     /**
      * Default ClamAV TCP port.


### PR DESCRIPTION
Fix #75: use ClamAV Debian image for Mac M1 Support