### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/antivirus/deployment/ClamAVDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/antivirus/deployment/ClamAVDevServicesProcessor.java
@@ -19,7 +19,7 @@ import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ContainerAddress;
 import io.quarkus.devservices.common.ContainerLocator;
@@ -28,7 +28,7 @@ import io.quarkus.devservices.common.ContainerShutdownCloseable;
 /**
  * Starts a ClamAV server as dev service if needed.
  */
-@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
 public class ClamAVDevServicesProcessor {
 
     private static final Logger log = Logger.getLogger(ClamAVDevServicesProcessor.class);
@@ -52,7 +52,7 @@ public class ClamAVDevServicesProcessor {
             ClamAVBuildConfig clamAVConfig,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
-            GlobalDevServicesConfig devServicesConfig,
+            DevServicesConfig devServicesConfig,
             BuildProducer<ClamAVDevServicesConfigBuildItem> clamAvBuildItemBuildProducer,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
 
@@ -112,7 +112,7 @@ public class ClamAVDevServicesProcessor {
 
     private DevServicesResultBuildItem.RunningDevService startClamAV(DockerStatusBuildItem dockerStatusBuildItem,
             ClamAVBuildConfig clamAVConfig,
-            GlobalDevServicesConfig devServicesConfig,
+            DevServicesConfig devServicesConfig,
             LaunchModeBuildItem launchMode,
             boolean useSharedNetwork) {
         if (!clamAVConfig.enabled()) {
@@ -144,7 +144,7 @@ public class ClamAVDevServicesProcessor {
 
         final Supplier<DevServicesResultBuildItem.RunningDevService> defaultClamAvSupplier = () -> {
             final ClamAVContainer container = new ClamAVContainer(clamAVConfig, useSharedNetwork);
-            devServicesConfig.timeout.ifPresent(container::withStartupTimeout);
+            devServicesConfig.timeout().ifPresent(container::withStartupTimeout);
             container.start();
 
             return new DevServicesResultBuildItem.RunningDevService(clamAVConfig.serviceName(),

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.15.3</quarkus.version>
+    <quarkus.version>3.20.0</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in 3.26 so we should avoid it.

> [!WARNING]
> Note that this requires to set the minimum version to 3.20, so you might have to have a maintenance branch for 3.15 if you want to push new versions supporting 3.15 after this is in.